### PR TITLE
feat: quick copy fixes and number display standardization

### DIFF
--- a/src/app/(pages)/(home)/component.tsx
+++ b/src/app/(pages)/(home)/component.tsx
@@ -35,8 +35,7 @@ export const HomePageComponent: FunctionComponent<HomePageComponentProps> = ({
     <Stack component="main">
       <HeroSectionSlim backgroundImage={backgroundImage.src} sx={{ mb: 0 }}>
         <Typography level="h1">
-          Nominate <Interface /> the best
-          builders <MusicHeadset /> you know.
+          Nominate <Interface /> the best builders <MusicHeadset /> you know.
         </Typography>
 
         <Typography level="title-lg" sx={{ maxWidth: "sm" }}>

--- a/src/app/(pages)/(home)/component.tsx
+++ b/src/app/(pages)/(home)/component.tsx
@@ -36,7 +36,6 @@ export const HomePageComponent: FunctionComponent<HomePageComponentProps> = ({
       <HeroSectionSlim backgroundImage={backgroundImage.src} sx={{ mb: 0 }}>
         <Typography level="h1">
           Nominate <Interface /> the best
-          <br />
           builders <MusicHeadset /> you know.
         </Typography>
 

--- a/src/app/_components/card-boss-points.tsx
+++ b/src/app/_components/card-boss-points.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from "react";
 import { Button, Stack, Typography, Link } from "@mui/joy";
 import { BlockyCard } from "@/shared/components/blocky-card";
 import { Dice } from "@/shared/icons/dice";
-import { formatNumber } from "@/shared/utils/format-number";
+import { formatLargeNumber, formatNumber } from "@/shared/utils/format-number";
 
 export type CardBossPointsProps = {
   points?: number;
@@ -24,7 +24,7 @@ export const CardBossPoints: FunctionComponent<CardBossPointsProps> = ({
         <Typography
           sx={{ fontSize: "36px", fontWeight: "bold", color: "common.black" }}
         >
-          {loading ? "---.--" : formatNumber(points)}
+          {loading ? "---.--" : formatLargeNumber(points)}
         </Typography>
       </Stack>
 

--- a/src/app/_components/card-boss-tokens.tsx
+++ b/src/app/_components/card-boss-tokens.tsx
@@ -7,6 +7,7 @@ import { base } from "viem/chains";
 import { useAccount, useReadContract } from "wagmi";
 import { BlockyCard } from "@/shared/components/blocky-card";
 import { Coin } from "@/shared/icons/coin";
+import { formatLargeNumber } from "@/shared/utils/format-number";
 
 export type BossTokensCardComponentProps = {
   address?: `0x${string}`;
@@ -28,26 +29,7 @@ export const CardBossTokens: FunctionComponent<
     query: { enabled: address !== undefined },
   });
 
-  const dividerToText = (divider: number) => {
-    if (divider === 1) return "";
-    if (divider === 1e3) return "K";
-    if (divider === 1e6) return "M";
-    if (divider === 1e9) return "B";
-    if (divider === 1e12) return "T";
-  };
-
-  const displayBalance = () => {
-    if (!tokens) return 0;
-    let divider = 1;
-
-    if (tokens < 1e18) return "~0";
-    else if (tokens < 1e21) divider = 1e3;
-    else if (tokens < 1e24) divider = 1e6;
-    else divider = 1e9;
-
-    const value = formatEther(tokens / BigInt(divider)).split(".");
-    return `${value[0]}.${value[1].slice(0, 2)}${dividerToText(divider)}`;
-  };
+  const numberTokens = Number(formatEther(tokens ?? BigInt(0)));
 
   return (
     <BlockyCard>
@@ -60,7 +42,7 @@ export const CardBossTokens: FunctionComponent<
         <Typography
           sx={{ fontSize: "36px", fontWeight: "bold", color: "common.black" }}
         >
-          {loading || isLoading ? "---.--" : displayBalance()}
+          {loading || isLoading ? "---.--" : formatLargeNumber(numberTokens)}
         </Typography>
       </Stack>
 

--- a/src/app/_components/table-leaderboard.tsx
+++ b/src/app/_components/table-leaderboard.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent } from "react";
 import { Sheet, SheetProps, Skeleton, Table } from "@mui/joy";
 import { abbreviateWalletAddress } from "@/shared/utils/abbreviate-wallet-address";
+import { formatLargeNumber, formatNumber } from "@/shared/utils/format-number";
 
 export type TableLeaderboardValue = {
   id: string;
@@ -46,8 +47,8 @@ export const TableLeaderboard: FunctionComponent<LeaderboardTableProps> = ({
             <tr key={val.id} className={val.highlight ? "blue" : ""}>
               <td>{val.rank}</td>
               <td>{shortenWallet(val.name)}</td>
-              <td>{Math.round(val.bossScore)}</td>
-              <td>{val.builderScore}</td>
+              <td>{formatLargeNumber(val.bossScore)}</td>
+              <td>{Math.round(val.builderScore)}</td>
               <td>{val.nominationsReceived ?? "Missed"}</td>
             </tr>
           ))}

--- a/src/app/_components/table-my-nominations.tsx
+++ b/src/app/_components/table-my-nominations.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent } from "react";
 import { Box, Sheet, SheetProps, Skeleton, Table } from "@mui/joy";
+import { formatLargeNumber } from "@/shared/utils/format-number";
 
 export type TableMyNominationsValue = {
   key: string;
@@ -49,7 +50,7 @@ export const TableMyNominations: FunctionComponent<MyNominationsTableProps> = ({
               <td>
                 {val.missed
                   ? "Missed"
-                  : Math.round(val.pointsGiven ?? 0) ?? "---"}
+                  : formatLargeNumber(val.pointsGiven ?? 0) ?? "---"}
               </td>
             </Box>
           ))}

--- a/src/shared/utils/format-number.ts
+++ b/src/shared/utils/format-number.ts
@@ -3,30 +3,30 @@
  * i.e. 1234567.89241 => 1,234,567.89
  */
 export const formatNumber = (n: number, decimalPoints: number = 2) => {
-  return n.toLocaleString("en-US", { 
+  return n.toLocaleString("en-US", {
     minimumFractionDigits: decimalPoints,
     maximumFractionDigits: decimalPoints,
   });
 };
 
 /**
- * Returns US style representation of a large number, using 
+ * Returns US style representation of a large number, using
  * metric prefixes (K, M, B) to abbreviate the number, always
  * with at least 3 significant digits. No decimal points.
- * 
- * i.e. 21_234_567 => 21,234M
+ *
+ * i.e. 21_234_567 => 21,235K
  * i.e. 3_121_234_567 => 3,121M
+ * i.e. 4_123_121_234_567 => 4,123B
  * i.e. 124.2412 => 124
  */
 export const formatLargeNumber = (n: number) => {
   const [divider, suffix] = (() => {
-    if (n > 1e12) return [1e9, "M"];
+    if (n > 1e12) return [1e9, "B"];
     if (n > 1e9) return [1e6, "M"];
     if (n > 1e6) return [1e3, "K"];
     return [1, ""];
   })();
 
-  console.log(n, divider);
   const basedNumber = n / divider;
   const localizedNumber = formatNumber(basedNumber, 0);
   return `${localizedNumber}${suffix}`;

--- a/src/shared/utils/format-number.ts
+++ b/src/shared/utils/format-number.ts
@@ -2,6 +2,32 @@
  * Returns US style representation of a number with 2 decimal places.
  * i.e. 1234567.89241 => 1,234,567.89
  */
-export const formatNumber = (n: number) => {
-  return n.toLocaleString("en-US", { minimumFractionDigits: 2 });
+export const formatNumber = (n: number, decimalPoints: number = 2) => {
+  return n.toLocaleString("en-US", { 
+    minimumFractionDigits: decimalPoints,
+    maximumFractionDigits: decimalPoints,
+  });
+};
+
+/**
+ * Returns US style representation of a large number, using 
+ * metric prefixes (K, M, B) to abbreviate the number, always
+ * with at least 3 significant digits. No decimal points.
+ * 
+ * i.e. 21_234_567 => 21,234M
+ * i.e. 3_121_234_567 => 3,121M
+ * i.e. 124.2412 => 124
+ */
+export const formatLargeNumber = (n: number) => {
+  const [divider, suffix] = (() => {
+    if (n > 1e12) return [1e9, "M"];
+    if (n > 1e9) return [1e6, "M"];
+    if (n > 1e6) return [1e3, "K"];
+    return [1, ""];
+  })();
+
+  console.log(n, divider);
+  const basedNumber = n / divider;
+  const localizedNumber = formatNumber(basedNumber, 0);
+  return `${localizedNumber}${suffix}`;
 };


### PR DESCRIPTION
- Fixes copy in home page. 
- Adds a new `formatLargeNumber` function that formats... wait for it... large numbers. 
   * i.e. 21_234_567 => 21,235K
   * i.e. 3_121_234_567 => 3,121M
   * i.e. 4_123_121_234_567 => 4,123B
   * i.e. 124.2412 => 124
 - use `formatLargeNumber` for boss tokens and boss score. use `formatNumber` for builderScore.
 