### PR TITLE
feat: add API call to buildbot.

### DIFF
--- a/src/app/_api/data/nominations.ts
+++ b/src/app/_api/data/nominations.ts
@@ -272,6 +272,24 @@ export const createNewNomination = async (
     });
   }
 
+  // call the buildbot API
+  const buildbotResponse = await fetch(`${process.env.BUILDBOT_API_URL}/webhooks/mentions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-webhook-key": `${process.env.BUILDBOT_WEBHOOK_KEY}`,
+    },
+    body: JSON.stringify({
+      points: balances.pointsGiven,
+      nominatorWallet: origin_wallet_id,
+      nominatedWallet: nominatedWallet.wallet,
+    }),
+  })
+
+  if (!buildbotResponse.ok) {
+    console.error(`an error occurred while calling the buildbot API`)
+  }
+
   revalidatePath(`/airdrop`);
   revalidatePath(`/airdrop/nominate/${nominatedWallet.wallet}`);
   revalidatePath(`/nominate/${nominatedWallet.wallet}`);

--- a/src/app/_api/external/buildbot.ts
+++ b/src/app/_api/external/buildbot.ts
@@ -1,0 +1,31 @@
+import { rollbarWarn } from "@/services/rollbar";
+
+export const notifyBuildBot = async (
+  nominatorWallet: string,
+  nominatedWallet: string,
+  points: number,
+) => {
+  try {
+    const buildbotResponse = await fetch(
+      `${process.env.BUILDBOT_API_URL}/webhooks/mentions`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-webhook-key": `${process.env.BUILDBOT_WEBHOOK_KEY}`,
+        },
+        body: JSON.stringify({
+          points,
+          nominatorWallet,
+          nominatedWallet,
+        }),
+      },
+    );
+
+    if (!buildbotResponse.ok) {
+      rollbarWarn("an error occurred while calling the buildbot API");
+    }
+  } catch (e) {
+    rollbarWarn(`an error occurred while calling the buildbot API: ${e}`);
+  }
+};


### PR DESCRIPTION
i've added an API call towards the buildbot when a nomination is created.

the API call sends the points used in the nomination and both the nominated and nominator wallet; these addresses are then used by the buildbot to retrieve the respective farcaster users, and if one of the two wallets does not have a farcaster profile, then no cast is created.

two new environment variables must be added in order for this to work:
- BUILDBOT_API_URL: the API url where the buildbot is deployed (TBD)
- BUILDBOT_WEBHOOK_KEY: a shared key between this API and the buildbot. this is mandatory in order to avoid other systems to call the exposed API of the buildbot.